### PR TITLE
ci: Add GitHub Actions workflow for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,100 @@
+name: e2e tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  WASP_TELEMETRY_DISABLE: 1
+  WASP_VERSION: 0.17.0
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Docker setup
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install Wasp
+        run: curl -sSL https://get.wasp.sh/installer.sh | sh -s -- -v ${{ env.WASP_VERSION }}
+
+      - name: Cache global node modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: node-modules-${{ runner.os }}-${{ hashFiles('app/package-lock.json') }}-${{ hashFiles('e2e-tests/package-lock.json') }}-wasp${{ env.WASP_VERSION }}-node${{ steps.setup-node.outputs.node-version }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+
+      - name: Set required wasp app env vars to mock values
+        run: |
+          cd app
+          cp .env.server.example .env.server && cp .env.client.example .env.client
+
+      - name: '[e2e-tests] Install Node.js dependencies for Playwright tests'
+        if: steps.cache-e2e-tests.outputs.cache-hit != 'true'
+        working-directory: ./e2e-tests
+        run: npm ci
+
+      - name: "[e2e-tests] Store Playwright's Version"
+        working-directory: ./e2e-tests
+        run: |
+          PLAYWRIGHT_VERSION=$(npm ls @playwright/test | grep @playwright | sed 's/.*@//')
+          echo "Playwright's Version: $PLAYWRIGHT_VERSION"
+          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
+
+      - name: "[e2e-tests] Cache Playwright Browsers for Playwright's Version"
+        id: cache-playwright-browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}-${{ runner.os }}
+
+      - name: '[e2e-tests] Set up Playwright'
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        working-directory: ./e2e-tests
+        run: npx playwright install --with-deps
+
+      - name: '[e2e-tests] Install Stripe CLI'
+        run: |
+          curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg
+          echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee -a /etc/apt/sources.list.d/stripe.list
+          sudo apt update
+          sudo apt install stripe
+
+      - name: '[e2e-tests] Run Stripe CLI to listen for webhooks'
+        env:
+          STRIPE_DEVICE_NAME: ${{ secrets.STRIPE_DEVICE_NAME }}
+        run: |
+          stripe listen --api-key ${{ secrets.STRIPE_KEY }} --forward-to localhost:3001/payments-webhook &
+
+      - name: '[e2e-tests] Run Playwright tests'
+        env:
+          # The e2e tests are testing parts of the app that need certain env vars, so we need to access them here.
+          # These secretes can be set in your GitHub repo settings, e.g. https://github.com/<account>/<repo>/settings/secrets/actions
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          STRIPE_API_KEY: ${{ secrets.STRIPE_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          STRIPE_CUSTOMER_PORTAL_URL: https://billing.stripe.com/p/login/test_8wM8x17JN7DT4zC000
+          PAYMENTS_HOBBY_SUBSCRIPTION_PLAN_ID: ${{ secrets.STRIPE_HOBBY_SUBSCRIPTION_PRICE_ID }}
+          PAYMENTS_PRO_SUBSCRIPTION_PLAN_ID: ${{ secrets.STRIPE_PRO_SUBSCRIPTION_PRICE_ID }}
+          PAYMENTS_CREDITS_10_PLAN_ID: ${{ secrets.STRIPE_CREDITS_PRICE_ID }}
+          SKIP_EMAIL_VERIFICATION_IN_DEV: true
+          # Client-side env vars
+          REACT_APP_GOOGLE_ANALYTICS_ID: G-H3LSJCK95H
+        working-directory: ./e2e-tests
+        run: npm run e2e:playwright


### PR DESCRIPTION
- Added a new workflow file at .github/workflows/e2e-tests.yml to run Playwright tests automatically on push/pull_request to main.
- The workflow is adapted from the standard OpenSaaS template.
- It installs Wasp, project dependencies, Playwright, and the Stripe CLI.
- It runs the full E2E test suite against a live instance of the app in the CI environment.
- Requires repository secrets for Stripe and OpenAI to be configured.